### PR TITLE
make context switching a 1s periodic check

### DIFF
--- a/context_switches.go
+++ b/context_switches.go
@@ -13,6 +13,8 @@ type contextSwitchChecker struct {
 
 func (csc contextSwitchChecker) Checks() []fthealth.Check {
 
+	go csc.updateCsCount()
+
 	check := fthealth.Check{
 		BusinessImpact:   "System may become unresponsive",
 		Name:             "Context switches check",
@@ -25,7 +27,7 @@ func (csc contextSwitchChecker) Checks() []fthealth.Check {
 	return []fthealth.Check{check}
 }
 
-func (csc contextSwitchChecker) switchCount() uint64 {
+func (csc contextSwitchChecker) count() uint64 {
 	d, err := linuxproc.ReadStat(*hostPath + "/proc/stat")
 	if err != nil {
 		panic(fmt.Sprintf("Cannot read disk info of %s file system.", *hostPath+"/proc/stat"))
@@ -34,12 +36,29 @@ func (csc contextSwitchChecker) switchCount() uint64 {
 }
 
 func (csc contextSwitchChecker) ctxCheck() error {
-	first := csc.switchCount()
-	time.Sleep(200 * time.Millisecond)
-	count := csc.switchCount() - first
-	perSec := count * 5
+	perSec := <-latestIntPerSec
 	if perSec > csc.threshold {
 		return fmt.Errorf("%d context switches per second. (>%d)", perSec, csc.threshold)
 	}
 	return nil
+}
+
+var latestCsPerSec chan uint64 = make(chan uint64)
+
+func (csc contextSwitchChecker) updateCsCount() {
+	ticker := time.NewTicker(1 * time.Second)
+	latestPerSec := uint64(0)
+	prevInt := uint64(0)
+	for {
+		select {
+		case latestCsPerSec <- latestPerSec:
+		case <-ticker.C:
+			newInt := csc.count()
+			if prevInt != 0 {
+				latestPerSec = newInt - prevInt
+			}
+			prevInt = newInt
+		}
+
+	}
 }


### PR DESCRIPTION
make context switching a 1s periodic check, just like the interrupts one.  This removed a 200ms delay, so the check overall now takes a few milliseconds instead 200+a few.