### PR TITLE
re-added inode check with a high threshold

### DIFF
--- a/disk_inodes.go
+++ b/disk_inodes.go
@@ -20,7 +20,7 @@ func (ic inodeChecker) Checks() []fthealth.Check {
 		Name:             "Root disk inode check",
 		PanicGuide:       panicGuide,
 		Severity:         2,
-		TechnicalSummary: "Please free some inodes on the 'root' mount",
+		TechnicalSummary: "Please free some inodes on the 'root' mount hint: df -i",
 		Checker:          ic.rootInodesCheck,
 	}
 
@@ -29,7 +29,7 @@ func (ic inodeChecker) Checks() []fthealth.Check {
 		Name:             "Persistent disk inode check on '/vol' (always true for stateless nodes)",
 		PanicGuide:       panicGuide,
 		Severity:         2,
-		TechnicalSummary: "Please clear some inodes on the 'vol' mount",
+		TechnicalSummary: "Please clear some inodes on the 'vol' mount hint: df -i",
 		Checker:          ic.mountedInodesCheck,
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	checks = append(checks, ntpChecker{}.Checks()...)
 	checks = append(checks, tcpChecker{}.Checks()...)
 	checks = append(checks, versionChecker{}.Checks()...)
+	checks = append(checks, inodeChecker{512}.Checks()...)
 
 	mux := mux.NewRouter()
 	mux.HandleFunc("/__health", fthealth.Handler("myserver", "a server", checks...))


### PR DESCRIPTION
Hi,

Added back in with low (ie less than 512 free inodes) which is near to broken.

If this flaps, you probably have a problem, but the value of this is that the errors you get will be obtuse ~ No space left on device, but df -h will often show loads of disk space, but df -i will show no inodes left.
