### PR TITLE
Change panic guide message to be slightly clearer

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	linuxproc "github.com/c9s/goprocinfo/linux"
-	"os"
 )
 
 type diskFreeChecker struct {
@@ -15,7 +16,7 @@ func (dff diskFreeChecker) Checks() []fthealth.Check {
 	rootCheck := fthealth.Check{
 		BusinessImpact:   "A part of the publishing workflow might be affected",
 		Name:             "Root disk space check",
-		PanicGuide:       "Please refer to technical summary",
+		PanicGuide:       "Please refer to the technical summary section below",
 		Severity:         2,
 		TechnicalSummary: "Please clear some disk space on the 'root' mount",
 		Checker:          dff.rootDiskSpaceCheck,
@@ -24,7 +25,7 @@ func (dff diskFreeChecker) Checks() []fthealth.Check {
 	mountedCheck := fthealth.Check{
 		BusinessImpact:   "A part of the publishing workflow might be effected",
 		Name:             "Persistent disk space check mounted on '/vol' (always true for stateless nodes)",
-		PanicGuide:       "Please refer to technical summary",
+		PanicGuide:       "Please refer to the technical summary section below",
 		Severity:         2,
 		TechnicalSummary: "Please clear some disk space on the 'vol' mount",
 		Checker:          dff.mountedDiskSpaceCheck,

--- a/diskio.go
+++ b/diskio.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	fthealth "github.com/Financial-Times/go-fthealth/v1a"
-	linuxproc "github.com/c9s/goprocinfo/linux"
 	"log"
 	"time"
+
+	fthealth "github.com/Financial-Times/go-fthealth/v1a"
+	linuxproc "github.com/c9s/goprocinfo/linux"
 )
 
 type iopsChecker struct {
@@ -49,7 +50,7 @@ func (ic iopsChecker) iopsCheck() (string, error) {
 	return fmt.Sprintf("%d", perSec), nil
 }
 
-var latestPerSec chan uint64 = make(chan uint64)
+var latestPerSec = make(chan uint64)
 
 func (ic iopsChecker) updateIopsCount() {
 	ticker := time.NewTicker(1 * time.Second)

--- a/loadavg.go
+++ b/loadavg.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	linuxproc "github.com/c9s/goprocinfo/linux"
 )
@@ -12,7 +13,7 @@ func (lac loadAverageChecker) Checks() []fthealth.Check {
 	check := fthealth.Check{
 		BusinessImpact:   "A part of the publishing workflow might be affected",
 		Name:             "CPU load average check",
-		PanicGuide:       "Please refer to technical summary",
+		PanicGuide:       "Please refer to the technical summary section below",
 		Severity:         2,
 		TechnicalSummary: "CPU is quite busy lately. This might not be a problem if it happens intermittently, however if it persists consider upgrading or adding new boxes.",
 		Checker:          lac.doCheck,

--- a/meminfo.go
+++ b/meminfo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	linuxproc "github.com/c9s/goprocinfo/linux"
 )
@@ -15,9 +16,9 @@ func (mc memoryChecker) Checks() []fthealth.Check {
 	check := fthealth.Check{
 		BusinessImpact:   "A part of the publishing workflow might be affected",
 		Name:             "Memory load check",
-		PanicGuide:       "Please refer to technical summary",
+		PanicGuide:       "Please refer to the technical summary section below",
 		Severity:         2,
-		TechnicalSummary: "Check the memory usage of services/containers on this host, please proceed conform these values.",
+		TechnicalSummary: "Check the memory usage of services/containers on this host, please confirm these values.",
 		Checker:          mc.avMemoryCheck,
 	}
 

--- a/ntp.go
+++ b/ntp.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	"github.com/bt51/ntpclient"
-	"time"
 )
 
 var offsetCh chan result
@@ -19,7 +20,7 @@ func (ntpc ntpChecker) Checks() []fthealth.Check {
 	ntpCheck := fthealth.Check{
 		BusinessImpact:   "A part of the publishing workflow might be affected",
 		Name:             "NTP sync check",
-		PanicGuide:       "Please refer to technical summary",
+		PanicGuide:       "Please refer to the technical summary section below",
 		Severity:         2,
 		TechnicalSummary: "System time has drifted out of sync of the box, investigate `timedatectl` and `systemd-timesyncd.service`",
 		Checker:          ntpc.Check,

--- a/tcp.go
+++ b/tcp.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	"net"
+
+	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 )
 
 type tcpChecker struct{}
@@ -12,7 +13,7 @@ func (tcpc tcpChecker) Checks() []fthealth.Check {
 	check := fthealth.Check{
 		BusinessImpact:   "A part of the publishing workflow might be affected",
 		Name:             "TCP connection to port 8080 is available",
-		PanicGuide:       "Please refer to technical summary",
+		PanicGuide:       "Please refer to the technical summary section below",
 		Severity:         2,
 		TechnicalSummary: "HTTP connections to port 8080 will not be successful to any of the services deployed on this machine if this falls.",
 		Checker:          tcpc.doCheck,


### PR DESCRIPTION
The panic guide message is shown as a link even though it isn't, so the message has been made a little clearer to point to where ops need to look.