### PR TITLE
Change free memory check to 15%

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	})
 
 	checks = append(checks, diskFreeChecker{20}.Checks()...)
-	checks = append(checks, memoryChecker{20}.Checks()...)
+	checks = append(checks, memoryChecker{15}.Checks()...)
 	checks = append(checks, loadAverageChecker{}.Checks()...)
 	checks = append(checks, ntpChecker{}.Checks()...)
 	checks = append(checks, tcpChecker{}.Checks()...)


### PR DESCRIPTION
The original value of 20% was not based on anything more than a guess.
We have seen machines with much less than 20% (around 10%) alerting but
actually working fine.

This reduces the threshold to 15%.