### PR TITLE
Deploy on push/k8s/deploy everywhere

### DIFF
--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -14,16 +14,9 @@ spec:
         app: {{ .Values.service.name }} 
         visualize: "true"
     spec:
+      # ensure that sys-hc will be deployed to all nodes
       tolerations:
-      # Making sure that system-hc will be scheduled on dedicated nodes for kafka and mongo
-      - key: "dedicated"
-        operator: "Equal"
-        value: "kafka"
-        effect: "NoSchedule"
-      - key: "dedicated"
-        operator: "Equal"
-        value: "mongo"
-        effect: "NoSchedule"
+      - operator: "Exists"
       containers:
       - name: {{ .Values.service.name }} 
         image: {{ .Values.image.repository }}:{{ .Chart.Version }}

--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -14,6 +14,16 @@ spec:
         app: {{ .Values.service.name }} 
         visualize: "true"
     spec:
+      tolerations:
+      # Making sure that system-hc will be scheduled on dedicated nodes for kafka and mongo
+      - key: "dedicated"
+        operator: "Equal"
+        value: "kafka"
+        effect: "NoSchedule"
+      - key: "dedicated"
+        operator: "Equal"
+        value: "mongo"
+        effect: "NoSchedule"
       containers:
       - name: {{ .Values.service.name }} 
         image: {{ .Values.image.repository }}:{{ .Chart.Version }}


### PR DESCRIPTION
- let system-healthcheck be deployed to all nodes, including dedicated kafka, mongo and controller nodes
- see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
- https://upp-k8s-publishing-test-eu.ft.com/__health/__pods-health?service-name=system-healthcheck
- https://upp-k8s-delivery-test-eu.ft.com/__health/__pods-health?service-name=system-healthcheck
