### PR TITLE
Deploy on push/k8s/update strategy

### DIFF
--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       # ensure that sys-hc will be deployed to all nodes
       tolerations:
       - operator: "Exists"
+      updateStrategy:
+      - type: RollingUpdate
       containers:
       - name: {{ .Values.service.name }} 
         image: {{ .Values.image.repository }}:{{ .Chart.Version }}

--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
           httpGet:
             path: /__gtg
             port: 8080
-          initialDelaySeconds: 10
+          initialDelaySeconds: 11
           periodSeconds: 30
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -8,6 +8,8 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.service.name }} 
+  updateStrategy:
+  - type: RollingUpdate
   template:
     metadata:
       labels:
@@ -17,8 +19,6 @@ spec:
       # ensure that sys-hc will be deployed to all nodes
       tolerations:
       - operator: "Exists"
-      updateStrategy:
-      - type: RollingUpdate
       containers:
       - name: {{ .Values.service.name }} 
         image: {{ .Values.image.repository }}:{{ .Chart.Version }}

--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -9,7 +9,7 @@ spec:
     matchLabels:
       app: {{ .Values.service.name }} 
   updateStrategy:
-  - type: RollingUpdate
+    type: "RollingUpdate"
   template:
     metadata:
       labels:

--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -35,12 +35,6 @@ spec:
           initialDelaySeconds: 5
           tcpSocket:
             port: 8080
-        readinessProbe:
-          httpGet:
-            path: /__gtg
-            port: 8080
-          initialDelaySeconds: 11
-          periodSeconds: 30
         resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:


### PR DESCRIPTION
- removed readiness probe as this is not a classic service, we use the `__health` and `__gtg` endpoints to determine the machine health
- configured a `RollingUpdate` policy so the daemon set is updated when a new version is deployed - more details in the [documentation](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy)