### PR TITLE
Implemented aggregated monitoring for AWS EBS mounts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,12 +68,6 @@
   revision = "7cafcd837844e784b526369c9bce262804aebc60"
 
 [[projects]]
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
-
-[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -96,6 +90,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ddc5252b008c7ca2e0c1bc2c1fad458ef8e304227eb84fc9c725fdfa802cb6f2"
+  inputs-digest = "9b1812bcf83d10297956c9ec2c42bb34e44cda5922fa0ebe56d7ee01ec50c0f4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,6 +68,12 @@
   revision = "7cafcd837844e784b526369c9bce262804aebc60"
 
 [[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -90,6 +96,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f3bc7d82cc5fd11ecce6e1df81086b48dd626306114069e8eb62403cac82182e"
+  inputs-digest = "ddc5252b008c7ca2e0c1bc2c1fad458ef8e304227eb84fc9c725fdfa802cb6f2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ docker build -t coco/coco-system-healthcheck .
 
 ## Actual checks:
 * Root disk space
-* Persistent disk space
+* AWS EBS mounts disk space
 * Memory load
 * CPU load average 
 * NTP synch

--- a/disk.go
+++ b/disk.go
@@ -27,16 +27,16 @@ func (dff diskFreeCheckerImpl) Checks() []fthealth.Check {
 		Name:             "Root disk space check",
 		PanicGuide:       "https://dewey.ft.com/upp-system-healthcheck.html",
 		Severity:         2,
-		TechnicalSummary: "Please clear some disk space on the 'root' mount",
+		TechnicalSummary: fmt.Sprintf("Free space on root volume is under %d%%",  dff.rootThresholdPercent),
 		Checker:          dff.RootDiskSpaceCheck,
 	}
 
 	mountedCheck := fthealth.Check{
 		BusinessImpact:   "A part of the publishing and delivery workflow might be effected",
-		Name:             "Persistent disk space check mounted on '" + *awsEbsMountPath + "'",
+		Name:             "AWS EBS volumes mounted under '" + *awsEbsMountPath + "'",
 		PanicGuide:       "https://dewey.ft.com/upp-system-healthcheck.html",
 		Severity:         2,
-		TechnicalSummary: "Please clear some disk space on the '" + *awsEbsMountPath + "' mount",
+		TechnicalSummary: fmt.Sprintf("Free space on mounted volumes under '%s' is under %d%%", *awsEbsMountPath,  dff.mountsThresholdPercent),
 		Checker:          dff.MountedDiskSpaceCheck,
 	}
 
@@ -50,9 +50,9 @@ func (dff diskFreeCheckerImpl) diskSpaceCheck(path string, thresholdPercent int)
 	}
 	pctAvail := (float64(d.Free) / float64(d.All) * 100)
 	if pctAvail < float64(thresholdPercent) {
-		return fmt.Sprintf("%s: %2.1f%%", path, pctAvail), fmt.Errorf("Low free space on %s. Free disk space: %2.1f%%", path, pctAvail)
+		return fmt.Sprintf("Free space on %s: %2.1f%%", path, pctAvail), fmt.Errorf("Low free space on %s. Free disk space: %2.1f%%", path, pctAvail)
 	}
-	return fmt.Sprintf("%s: %2.1f%%", path, pctAvail), nil
+	return fmt.Sprintf("Free space on %s: %2.1f%%", path, pctAvail), nil
 }
 
 func (dff diskFreeCheckerImpl) RootDiskSpaceCheck() (string, error) {

--- a/disk.go
+++ b/disk.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"errors"
 	fthealth "github.com/Financial-Times/go-fthealth/v1_1"
 	linuxproc "github.com/c9s/goprocinfo/linux"
-	"github.com/pkg/errors"
 	"io/ioutil"
 )
 
@@ -27,7 +27,7 @@ func (dff diskFreeCheckerImpl) Checks() []fthealth.Check {
 		Name:             "Root disk space check",
 		PanicGuide:       "https://dewey.ft.com/upp-system-healthcheck.html",
 		Severity:         2,
-		TechnicalSummary: fmt.Sprintf("Free space on root volume is under %d%%",  dff.rootThresholdPercent),
+		TechnicalSummary: fmt.Sprintf("Free space on root volume is under %d%%", dff.rootThresholdPercent),
 		Checker:          dff.RootDiskSpaceCheck,
 	}
 
@@ -36,7 +36,7 @@ func (dff diskFreeCheckerImpl) Checks() []fthealth.Check {
 		Name:             "AWS EBS volumes mounted under '" + *awsEbsMountPath + "'",
 		PanicGuide:       "https://dewey.ft.com/upp-system-healthcheck.html",
 		Severity:         2,
-		TechnicalSummary: fmt.Sprintf("Free space on mounted volumes under '%s' is under %d%%", *awsEbsMountPath,  dff.mountsThresholdPercent),
+		TechnicalSummary: fmt.Sprintf("Free space on mounted volumes under '%s' is under %d%%", *awsEbsMountPath, dff.mountsThresholdPercent),
 		Checker:          dff.MountedDiskSpaceCheck,
 	}
 
@@ -48,7 +48,7 @@ func (dff diskFreeCheckerImpl) diskSpaceCheck(path string, thresholdPercent int)
 	if err != nil {
 		return "", fmt.Errorf("Cannot read disk info of %s file system.", path)
 	}
-	pctAvail := (float64(d.Free) / float64(d.All) * 100)
+	pctAvail := float64(d.Free) / float64(d.All) * 100
 	if pctAvail < float64(thresholdPercent) {
 		return fmt.Sprintf("Free space on %s: %2.1f%%", path, pctAvail), fmt.Errorf("Low free space on %s. Free disk space: %2.1f%%", path, pctAvail)
 	}

--- a/gtg.go
+++ b/gtg.go
@@ -11,9 +11,9 @@ type gtgService struct {
 	ntpc ntpChecker
 }
 
-func newGtgService(diskThresholdPercent, memoryThresholdPercent float64) *gtgService {
+func newGtgService(rootDiskThresholdPercent int, mountsThresholdPercent int, memoryThresholdPercent float64) *gtgService {
 	return &gtgService{
-		dfc:  diskFreeCheckerImpl{diskThresholdPercent},
+		dfc:  diskFreeCheckerImpl{rootDiskThresholdPercent, mountsThresholdPercent},
 		mc:   memoryCheckerImpl{memoryThresholdPercent},
 		lac:  loadAverageCheckerImpl{},
 		ntpc: &ntpCheckerImpl{},

--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -29,6 +29,12 @@ spec:
         env:
         - name: SYS_HC_HOST_PATH
           value: {{ .Values.env.system_hc_host_path }}
+        - name: AWS_EBS_MOUNTS_PATH
+          value: {{ .Values.env.aws_ebs_mounts_path }}
+        - name: MOUNTS_THRESHOLD
+          value: "{{ .Values.env.mounts_threshold }}"
+        - name: ROOT_DISK_THRESHOLD
+          value: "{{ .Values.env.root_disk_threshold }}"
         - name: NTP_TIME_DRIFT
           value: {{ .Values.env.ntp_time_drift }}
         - name: NTP_POLLING_PERIOD

--- a/helm/system-healthcheck/templates/daemonset.yaml
+++ b/helm/system-healthcheck/templates/daemonset.yaml
@@ -31,10 +31,10 @@ spec:
           value: {{ .Values.env.system_hc_host_path }}
         - name: AWS_EBS_MOUNTS_PATH
           value: {{ .Values.env.aws_ebs_mounts_path }}
-        - name: MOUNTS_THRESHOLD
-          value: "{{ .Values.env.mounts_threshold }}"
-        - name: ROOT_DISK_THRESHOLD
-          value: "{{ .Values.env.root_disk_threshold }}"
+        - name: MOUNTS_THRESHOLD_PERCENT
+          value: "{{ .Values.env.mounts_threshold_percent }}"
+        - name: ROOT_DISK_THRESHOLD_PERCENT
+          value: "{{ .Values.env.root_disk_threshold_percent }}"
         - name: NTP_TIME_DRIFT
           value: {{ .Values.env.ntp_time_drift }}
         - name: NTP_POLLING_PERIOD

--- a/helm/system-healthcheck/values.yaml
+++ b/helm/system-healthcheck/values.yaml
@@ -11,6 +11,9 @@ image:
   pullPolicy: IfNotPresent
 env:
     system_hc_host_path: "host_dir"
+    aws_ebs_mounts_path: "/var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/aws"
+    mounts_threshold: "10"
+    root_disk_threshold: "20"
     ntp_time_drift: "2s"
     ntp_polling_period: "1m"
 volumes:

--- a/helm/system-healthcheck/values.yaml
+++ b/helm/system-healthcheck/values.yaml
@@ -12,8 +12,8 @@ image:
 env:
     system_hc_host_path: "host_dir"
     aws_ebs_mounts_path: "/var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/aws"
-    mounts_threshold: "10"
-    root_disk_threshold: "20"
+    mounts_threshold_percent: "10"
+    root_disk_threshold_percent: "20"
     ntp_time_drift: "2s"
     ntp_polling_period: "1m"
 volumes:

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 		Name:   "rootDiskThresholdPercent",
 		Value:  20,
 		Desc:   "For monitoring the root disk of the instances: when the free space goes bellow this percentage, the health check will fail",
-		EnvVar: "ROOT_DISK_THRESHOLD",
+		EnvVar: "ROOT_DISK_THRESHOLD_PERCENT",
 	})
 
 	awsEbsMountPath = app.String(cli.StringOpt{
@@ -54,7 +54,7 @@ func main() {
 		Name:   "mountsThresholdPercent",
 		Value:  10,
 		Desc:   "For monitoring the AWS EBSs that are mounted by Kubernetes: when the free space goes bellow this percentage, the health check will fail",
-		EnvVar: "MOUNTS_THRESHOLD",
+		EnvVar: "MOUNTS_THRESHOLD_PERCENT",
 	})
 
 	ntpTimeDrift = app.String(cli.StringOpt{

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	rootDiskThresholdPercent = app.Int(cli.IntOpt{
 		Name:   "rootDiskThresholdPercent",
 		Value:  20,
-		Desc:   "For monitoring the root disk of the instances: when the free space goes bellow this percentage, the health check will fail",
+		Desc:   "For monitoring the root disk of the instances: when the free space goes below this percentage, the health check will fail",
 		EnvVar: "ROOT_DISK_THRESHOLD_PERCENT",
 	})
 

--- a/main.go
+++ b/main.go
@@ -13,14 +13,16 @@ import (
 )
 
 var (
-	checks           []fthealth.Check
-	hostPath         *string
-	ntpTimeDrift     *string
-	ntpPollingPeriod *string
+	checks                   []fthealth.Check
+	hostPath                 *string
+	awsEbsMountPath          *string
+	ntpTimeDrift             *string
+	ntpPollingPeriod         *string
+	rootDiskThresholdPercent *int
+	mountsThresholdPercent   *int
 )
 
 const (
-	diskThresholdPercent   = 20
 	memoryThresholdPercent = 15
 )
 
@@ -32,6 +34,27 @@ func main() {
 		Value:  "",
 		Desc:   "The dir path of the mounted host fs (in the container)",
 		EnvVar: "SYS_HC_HOST_PATH",
+	})
+
+	rootDiskThresholdPercent = app.Int(cli.IntOpt{
+		Name:   "rootDiskThresholdPercent",
+		Value:  20,
+		Desc:   "For monitoring the root disk of the instances: when the free space goes bellow this percentage, the health check will fail",
+		EnvVar: "ROOT_DISK_THRESHOLD",
+	})
+
+	awsEbsMountPath = app.String(cli.StringOpt{
+		Name:   "awsEbsMountPath",
+		Value:  "",
+		Desc:   "The folder path where the AWS EBSs are mounted by Kubernetes",
+		EnvVar: "AWS_EBS_MOUNTS_PATH",
+	})
+
+	mountsThresholdPercent = app.Int(cli.IntOpt{
+		Name:   "mountsThresholdPercent",
+		Value:  10,
+		Desc:   "For monitoring the AWS EBSs that are mounted by Kubernetes: when the free space goes bellow this percentage, the health check will fail",
+		EnvVar: "MOUNTS_THRESHOLD",
 	})
 
 	ntpTimeDrift = app.String(cli.StringOpt{
@@ -65,7 +88,7 @@ func main() {
 		pollingPeriod: ntpPollingPeriodDuration,
 	}
 
-	checks = append(checks, diskFreeCheckerImpl{diskThresholdPercent}.Checks()...)
+	checks = append(checks, diskFreeCheckerImpl{*rootDiskThresholdPercent, *mountsThresholdPercent}.Checks()...)
 	checks = append(checks, memoryCheckerImpl{memoryThresholdPercent}.Checks()...)
 	checks = append(checks, loadAverageCheckerImpl{}.Checks()...)
 	checks = append(checks, ntpChecker.Checks()...)
@@ -81,7 +104,7 @@ func main() {
 		Timeout: 10 * time.Second,
 	}
 	r.HandleFunc("/__health", fthealth.Handler(timedHC))
-	gtgService := newGtgService(diskThresholdPercent, memoryThresholdPercent)
+	gtgService := newGtgService(*rootDiskThresholdPercent, *mountsThresholdPercent, memoryThresholdPercent)
 	r.HandleFunc(status.GTGPath, status.NewGoodToGoHandler(gtgService.Check))
 
 	log.Print("Starting http server on 8080\n")


### PR DESCRIPTION
The EBSs are mounted on a specific path under /var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/aws/. The implementation looks in all the volumes in this path.

Updated README
Extracted disk thresholds as params.
Updated Helm chart