### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - System Healthcheck
 
 A service that monitors key system metrics for the EC2 instances in our containerised clusters.
@@ -18,23 +22,6 @@ Bronze
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- elitsa.pavlova
-- hristo.georgiev
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
-
 ## Host Platform
 
 AWS
@@ -50,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -87,6 +88,14 @@ Manual
 
 The release is triggered by making a Github release which is then picked up by a Jenkins multibranch pipeline. The Jenkins pipeline should be manually started in order for it to deploy the helm package to the Kubernetes clusters.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 NotApplicable
@@ -99,12 +108,12 @@ There is no key rotation procedure for this system.
 
 Pod health:
 
-- <https://upp-prod-delivery-eu.ft.com/__health/__pods-health?service-name=system-healthcheck>
-- <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=system-healthcheck>
-- <https://upp-prod-delivery-us.ft.com/__health/__pods-health?service-name=system-healthcheck>
-- <https://upp-prod-publish-us.ft.com/__health/__pods-health?service-name=system-healthcheck>
-- <https://pac-prod-eu.upp.ft.com/__health/__pods-health?service-name=system-healthcheck>
-- <https://pac-prod-us.upp.ft.com/__health/__pods-health?service-name=system-healthcheck>
+*   <https://upp-prod-delivery-eu.ft.com/__health/__pods-health?service-name=system-healthcheck>
+*   <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=system-healthcheck>
+*   <https://upp-prod-delivery-us.ft.com/__health/__pods-health?service-name=system-healthcheck>
+*   <https://upp-prod-publish-us.ft.com/__health/__pods-health?service-name=system-healthcheck>
+*   <https://pac-prod-eu.upp.ft.com/__health/__pods-health?service-name=system-healthcheck>
+*   <https://pac-prod-us.upp.ft.com/__health/__pods-health?service-name=system-healthcheck>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/coco-system-healthcheck/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **upp-system-healthcheck** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **upp-system-healthcheck** system in [Biz Ops](https://biz-ops.in.ft.com/System/upp-system-healthcheck).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
